### PR TITLE
Improve --underscore-namespaces implementation

### DIFF
--- a/src/Dependencies/DependencyFilter.php
+++ b/src/Dependencies/DependencyFilter.php
@@ -145,8 +145,7 @@ class DependencyFilter
             if (strpos($dependency->toString(), '_') === false) {
                 return $dependency;
             }
-            // do not change class which already use namespace
-            if (strpos($dependency->toString(), '\\') !== false) {
+            if ($dependency->isNamespaced()) {
                 return $dependency;
             }
             if ($dependency instanceof Namespaze) {

--- a/src/Dependencies/DependencyFilter.php
+++ b/src/Dependencies/DependencyFilter.php
@@ -145,6 +145,10 @@ class DependencyFilter
             if (strpos($dependency->toString(), '_') === false) {
                 return $dependency;
             }
+            // do not change class which already use namespace
+            if (strpos($dependency->toString(), '\\') !== false) {
+                return $dependency;
+            }
             if ($dependency instanceof Namespaze) {
                 return new Namespaze(explode('_', $dependency->toString()));
             }

--- a/tests/unit/Dependencies/DependencyFilterTest.php
+++ b/tests/unit/Dependencies/DependencyFilterTest.php
@@ -46,12 +46,10 @@ class DependencyFilterTest extends \PHPUnit_Framework_TestCase
             DependencyHelper::map('
                 A\\b\\c --> D\\e\\f
                 F\\a --> D\\b
-                _A\\b --> _B\\c
             '),
             $this->filter->mapNamespaces(DependencyHelper::map('
                 A_b_c --> D_e_f
                 F_a --> D_b
-                _A_b --> _B_c
             '))
         );
     }

--- a/tests/unit/Dependencies/DependencyFilterTest.php
+++ b/tests/unit/Dependencies/DependencyFilterTest.php
@@ -56,6 +56,20 @@ class DependencyFilterTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testMapUnderscoreNamespacesAlreadyNamespace()
+    {
+        $this->assertEquals(
+            DependencyHelper::map('
+                VendorA\\Tests\\DDC1209_1 --> a\\To
+                A\\__b__\\c --> D\\e\\f
+            '),
+            $this->filter->mapNamespaces(DependencyHelper::map('
+                VendorA\\Tests\\DDC1209_1 --> a\\To
+                A\\__b__\\c --> D\\e\\f
+            '))
+        );
+    }
+
     public function testFilterByDepthThree()
     {
         $dependencies = DependencyHelper::map('


### PR DESCRIPTION
Improves implementaion of **--underscore-namespaces** when applied on classes that **already have namespace**.

Current implementation is changing **all** classnames that contains underscores, even if they **already use namespace**. That behaviour causes Fatal errors, e.g.:
PHP Fatal error:  Uncaught InvalidArgumentException: Class name "1" is not valid

Reproducible e.g. on doctrine2 tests directory (just an example with publicly downloadable project).

This pull request **allows to use dephpend on older projects** that combine classes **with** and **without** **namespaces** or projects without namespaces which contains libraries with namespaces in the scr directory.
