### PR TITLE
Fix branch based version to use when installing using composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ phive install --copy dephpend
 You can install dePHPend globally, but this might lead to problems if other globally installed QA tools use different versions of PhpParser for instance.
 
 ```bash
-composer global require dephpend/dephpend:dev-master
+composer global require dephpend/dephpend:dev-main
 ```
 
 ### Manual .phar download


### PR DESCRIPTION
Trying to install the command in the README to install `dephpend` using composer 
```
composer require dephpend/dephpend:dev-master
```
yields the following error
```
  [InvalidArgumentException]
  Could not find package dephpend/dephpend in a version matching dev-master
```
the `dev-main` version should be used instead

```
composer require dephpend/dephpend:dev-main
```
```