### PR TITLE
Finalize PHP 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
     - "7.4"
     - "7.3"
     - "7.2"
+    - "8.0"
 
 install:
     - "mkdir -p build/logs"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "homepage": "https://dephpend.com",
     "bin": ["bin/dephpend", "bin/php-trace"],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "nikic/php-parser": "^4.0",
         "symfony/console": "^4 || ^5",
         "symfony/event-dispatcher": "^4 || ^5"

--- a/src/Analyser/XDebugFunctionTraceAnalyser.php
+++ b/src/Analyser/XDebugFunctionTraceAnalyser.php
@@ -30,7 +30,7 @@ class XDebugFunctionTraceAnalyser
 
     public function analyse(\SplFileInfo $file) : DependencyMap
     {
-        $fileHandle = @fopen($file->getPathname(), 'r');
+        $fileHandle = !empty($file->getPathname()) ? @fopen($file->getPathname(), 'r') : false;
         if (!$fileHandle) {
             throw new \InvalidArgumentException('Unable to open trace file for reading');
         }

--- a/tests/unit/Util/DependencyContainerTest.php
+++ b/tests/unit/Util/DependencyContainerTest.php
@@ -25,7 +25,7 @@ class DependencyContainerTest extends TestCase
             if (!$method->hasReturnType()) {
                 continue;
             }
-            $methods[] = [$method->getName(), (string) $method->getReturnType()];
+            $methods[] = [$method->getName(), $method->getReturnType()->getName()];
         }
         return $methods;
     }


### PR DESCRIPTION
I see that https://github.com/mihaeu/dephpend/commit/075d60da5571ad0bd3f1b0fd7607896795a69334 adds PHP 8 support, but some things are still missing:
1. travis-ci configuration still does not mention PHP 8
2. composer config does not have PHP 8 support, which means that installing through composer requires `--ignore-platform-req php` 

Note that Travis CI still breaks on PHP 8 because of code coverage, which is not supported for PHP 8 with the current PHPUnit version. I could upgrade PHPUnit to 9.5 (and make the required fixes in tests), but that would mean PHP 7.2 would no longer be supported (PHP 7.3 would be the minimum version).

Perhaps we could leave code coverage out? Or what is your preferred way of handling this?